### PR TITLE
Default to `npm` as type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module.exports = {
 
     let checker = new VersionChecker(this);
 
-    checker.for('ember-cli', 'npm').assertAbove('2.0.0');
+    checker.for('ember-cli').assertAbove('2.0.0');
   }
 };
 ```
@@ -36,7 +36,7 @@ module.exports = {
   init: function() {
     let checker = new VersionChecker(this);
 
-    checker.for('ember-cli', 'npm').assertAbove('2.0.0', 'To use awesome-addon you must have ember-cli 2.0.0');
+    checker.for('ember-cli').assertAbove('2.0.0', 'To use awesome-addon you must have ember-cli 2.0.0');
   }
 };
 ```
@@ -52,7 +52,7 @@ module.exports = {
   name: 'awesome-addon',
   init: function() {
     let checker = new VersionChecker(this);
-    let dep = checker.for('ember-cli', 'npm');
+    let dep = checker.for('ember-cli');
 
     if (dep.isAbove('2.0.0')) {
       /* deal with 2.0.0 stuff */

--- a/src/version-checker.js
+++ b/src/version-checker.js
@@ -14,7 +14,7 @@ class VersionChecker {
   for(name, type) {
     if (type === 'bower') {
       return new BowerDependencyVersionChecker(this, name);
-    } else if (type === 'npm') {
+    } else {
       return new NPMDependencyVersionChecker(this, name);
     }
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -52,6 +52,20 @@ describe('ember-cli-version-checker', function() {
       checker = new VersionChecker(addon);
     });
 
+    describe('specified type', function() {
+      it('defaults to `npm`', function() {
+        let thing = checker.for('ember');
+
+        assert.equal(thing.version, '2.0.0');
+      });
+
+      it('allows `bower`', function() {
+        let thing = checker.for('ember', 'bower');
+
+        assert.equal(thing.version, '1.12.1');
+      });
+    });
+
     describe('version', function() {
       it('can return a bower version', function() {
         let thing = checker.for('ember', 'bower');


### PR DESCRIPTION
Now that bower is on its way out, there is no need to always require this type argument to be specified.