### PR TITLE
[DOCS]: Document semver methods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ module.exports = {
 
 ## API
 
+### Semver Methods (gt, lt, gte, lte, eq, neq, satisfies)
+
+See https://github.com/npm/node-semver#comparison and https://github.com/npm/node-semver#ranges-1 for more info
+
+```js
+let VersionChecker = require('ember-cli-version-checker');
+
+module.exports = {
+  name: 'awesome-addon',
+  init() {
+    let checker = new VersionChecker(this);
+    let dep = checker.for('ember-cli');
+
+    if (dep.gte('2.0.0')) {
+      /* deal with 2.0.0+ stuff */
+    } else {
+      /* provide backwards compat */
+    };
+  }
+};
+```
+
 ### assertAbove
 
 Throws an error with the given message if a minimum version isn't met.


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli-version-checker/blob/master/src/dependency-version-checker.js#L69 weren't documented in the README.
 
Let me know if you want to update in any way for clarity or style 