### PR TITLE
[bugfix] Allow VersionChecker to work with Projects

### DIFF
--- a/src/bower-dependency-version-checker.js
+++ b/src/bower-dependency-version-checker.js
@@ -8,12 +8,22 @@ class BowerDependencyVersionChecker extends DependencyVersionChecker {
     super(parent, name);
 
     let addon = this._parent._addon;
-    let project = addon.project;
-    let bowerDependencyPath = path.join(
-      project.root,
-      project.bowerDirectory,
-      this.name
-    );
+
+    let root, bowerDirectory;
+
+    if (addon.project) {
+      root = addon.project.root;
+      bowerDirectory = addon.project.bowerDirectory;
+    } else if (addon.root && addon.bowerDirectory) {
+      root = addon.root;
+      bowerDirectory = addon.bowerDirectory;
+    } else {
+      throw new Error(
+        'You must provide an Addon, EmberApp/EmberAddon, or Project to check bower dependencies against'
+      );
+    }
+
+    let bowerDependencyPath = path.join(root, bowerDirectory, this.name);
 
     this._jsonPath = path.join(bowerDependencyPath, '.bower.json');
     this._fallbackJsonPath = path.join(bowerDependencyPath, 'bower.json');

--- a/src/dependency-version-checker.js
+++ b/src/dependency-version-checker.js
@@ -51,9 +51,11 @@ class DependencyVersionChecker {
     let message = _message;
 
     if (!message) {
-      message = `The addon \`${this._parent._addon.name}\` requires the ${this
-        ._type} package \`${this
-        .name}\` to be above ${compareVersion}, but you have ${this.version}.`;
+      message = `The addon \`${this._parent._addon.name}\` requires the ${
+        this._type
+      } package \`${this.name}\` to be above ${compareVersion}, but you have ${
+        this.version
+      }.`;
     }
 
     if (!this.isAbove(compareVersion)) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -33,13 +33,17 @@ function buildBowerPackage(name, version, disableBowerVersion) {
 describe('ember-cli-version-checker', function() {
   let projectRoot;
 
+  class FakeProject {
+    constructor() {
+      this.root = projectRoot.path();
+      this.bowerDirectory = 'bower_components';
+    }
+  }
+
   class FakeAddon {
-    constructor(project) {
-      (this.root = projectRoot.path('node_modules/fake-addon')),
-        (this.project = project || {
-          root: projectRoot.path(),
-          bowerDirectory: 'bower_components',
-        });
+    constructor() {
+      this.project = new FakeProject();
+      this.root = projectRoot.path('node_modules/fake-addon');
       this.name = 'fake-addon';
     }
   }
@@ -50,389 +54,405 @@ describe('ember-cli-version-checker', function() {
     })
   );
 
-  describe('VersionChecker#forEmber', function() {
-    let addon, checker, projectContents;
+  for (let scenario of ['addon', 'project']) {
+    describe(`with ${scenario}`, function() {
+      let FakeClass = scenario === 'addon' ? FakeAddon : FakeProject;
 
-    beforeEach(function() {
-      projectContents = {
-        bower_components: {
-          ember: buildBowerPackage('ember', '1.13.2'),
-        },
-        node_modules: {
-          'ember-source': buildPackage('ember-source', '2.10.0'),
-        },
-      };
+      describe('VersionChecker#forEmber', function() {
+        let addon, checker, projectContents;
 
-      addon = new FakeAddon();
-
-      checker = new VersionChecker(addon);
-    });
-
-    describe('version', function() {
-      it('returns the bower version if ember-source is not present in npm', function() {
-        delete projectContents['node_modules'];
-        projectRoot.write(projectContents);
-
-        let thing = checker.forEmber();
-        assert.equal(thing.version, '1.13.2');
-      });
-
-      it('returns the ember-source version before looking for ember in bower', function() {
-        projectRoot.write(projectContents);
-        let thing = checker.forEmber();
-        assert.equal(thing.version, '2.10.0');
-      });
-    });
-  });
-
-  describe('VersionChecker#for', function() {
-    let addon, checker;
-    beforeEach(function() {
-      projectRoot.write({
-        bower_components: {
-          ember: buildBowerPackage('ember', '1.12.1'),
-        },
-        node_modules: {
-          ember: buildPackage('ember', '2.0.0'),
-        },
-      });
-
-      addon = new FakeAddon();
-
-      checker = new VersionChecker(addon);
-    });
-
-    afterEach(function() {
-      return projectRoot.dispose();
-    });
-
-    describe('nested packages', function() {
-      it('finds nested packages from the current addons root', function() {
-        projectRoot.write({
-          node_modules: {
-            bar: buildPackage('bar', '3.0.0'),
-            'fake-addon': {
-              node_modules: {
-                bar: buildPackage('bar', '2.0.0'),
-              },
+        beforeEach(function() {
+          projectContents = {
+            bower_components: {
+              ember: buildBowerPackage('ember', '1.13.2'),
             },
-          },
+            node_modules: {
+              'ember-source': buildPackage('ember-source', '2.10.0'),
+            },
+          };
+
+          addon = new FakeClass();
+
+          checker = new VersionChecker(addon);
         });
 
-        addon.root = projectRoot.path('node_modules/fake-addon');
+        describe('version', function() {
+          it('returns the bower version if ember-source is not present in npm', function() {
+            delete projectContents['node_modules'];
+            projectRoot.write(projectContents);
 
-        let thing = checker.for('bar');
+            let thing = checker.forEmber();
+            assert.equal(thing.version, '1.13.2');
+          });
 
-        assert.equal(thing.version, '2.0.0');
-      });
-    });
-
-    describe('specified type', function() {
-      it('defaults to `npm`', function() {
-        let thing = checker.for('ember');
-
-        assert.equal(thing.version, '2.0.0');
-      });
-
-      it('allows `bower`', function() {
-        let thing = checker.for('ember', 'bower');
-
-        assert.equal(thing.version, '1.12.1');
-      });
-    });
-
-    describe('exists', function() {
-      it('returns true when present', function() {
-        let thing = checker.for('ember');
-
-        assert.ok(thing.exists());
+          it('returns the ember-source version before looking for ember in bower', function() {
+            projectRoot.write(projectContents);
+            let thing = checker.forEmber();
+            assert.equal(thing.version, '2.10.0');
+          });
+        });
       });
 
-      it('returns false when not present', function() {
-        let thing = checker.for('rando-thing-here');
+      describe('VersionChecker#for', function() {
+        let addon, checker;
+        beforeEach(function() {
+          projectRoot.write({
+            bower_components: {
+              ember: buildBowerPackage('ember', '1.12.1'),
+            },
+            node_modules: {
+              ember: buildPackage('ember', '2.0.0'),
+            },
+          });
 
-        assert.ok(!thing.exists());
-      });
-    });
+          addon = new FakeClass();
 
-    describe('version', function() {
-      it('can return a bower version', function() {
-        let thing = checker.for('ember', 'bower');
-
-        assert.equal(thing.version, '1.12.1');
-      });
-
-      it('can return a fallback bower version for non-tagged releases', function() {
-        projectRoot.write({
-          bower_components: {
-            ember: buildBowerPackage('ember', '1.13.2', true),
-          },
+          checker = new VersionChecker(addon);
         });
 
-        let thing = checker.for('ember', 'bower');
-
-        assert.equal(thing.version, '1.13.2');
-      });
-
-      it('can return a npm version', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.version, '2.0.0');
-      });
-
-      it('does not exist in bower_components', function() {
-        let thing = checker.for('does-not-exist-dummy', 'bower');
-
-        assert.equal(thing.version, null);
-      });
-
-      it('does not exist in nodeModulesPath', function() {
-        let thing = checker.for('does-not-exist-dummy', 'npm');
-
-        assert.equal(thing.version, null);
-      });
-    });
-
-    describe('satisfies', function() {
-      it('returns true if version is included within range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.satisfies('>= 0.0.1'), true);
-      });
-
-      it('returns false if version is not included within range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.satisfies('>= 99.0.0'), false);
-      });
-
-      it('returns false if the dependency does not exist', function() {
-        checker = new VersionChecker(addon);
-        let thing = checker.for('derp', 'npm');
-
-        assert.equal(thing.satisfies('>= 2.9'), false);
-      });
-    });
-
-    describe('isAbove', function() {
-      it('returns true if version is above the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.isAbove('0.0.1'), true);
-      });
-
-      it('returns false if version is below the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.isAbove('99.0.0'), false);
-      });
-
-      it('returns true on beta releases if version is above the specified range', function() {
-        projectRoot.write({
-          bower_components: {
-            ember: buildBowerPackage('ember', '2.3.0-beta.2+41030996', true),
-          },
+        afterEach(function() {
+          return projectRoot.dispose();
         });
 
-        let thing = checker.for('ember', 'bower');
+        describe('nested packages', function() {
+          it('finds nested packages from the current addons root', function() {
+            projectRoot.write({
+              node_modules: {
+                bar: buildPackage('bar', '3.0.0'),
+                'fake-addon': {
+                  node_modules: {
+                    bar: buildPackage('bar', '2.0.0'),
+                  },
+                },
+              },
+            });
 
-        assert.equal(thing.isAbove('2.2.0'), true);
-      });
+            addon.root = projectRoot.path('node_modules/fake-addon');
 
-      it('returns false on beta releases if version is below the specified range', function() {
-        projectRoot.write({
-          bower_components: {
-            ember: buildBowerPackage('ember', '2.3.0-beta.2+41030996', true),
-          },
+            let thing = checker.for('bar');
+
+            assert.equal(thing.version, '2.0.0');
+          });
         });
 
-        let thing = checker.for('ember', 'bower');
+        describe('specified type', function() {
+          it('defaults to `npm`', function() {
+            let thing = checker.for('ember');
 
-        assert.equal(thing.isAbove('2.3.0'), false);
-      });
+            assert.equal(thing.version, '2.0.0');
+          });
 
-      it('returns false if the dependency does not exist', function() {
-        checker = new VersionChecker(addon);
-        let thing = checker.for('derpy-herpy', 'npm');
+          it('allows `bower`', function() {
+            let thing = checker.for('ember', 'bower');
 
-        assert.equal(thing.isAbove('2.9.0'), false);
+            assert.equal(thing.version, '1.12.1');
+          });
+        });
+
+        describe('exists', function() {
+          it('returns true when present', function() {
+            let thing = checker.for('ember');
+
+            assert.ok(thing.exists());
+          });
+
+          it('returns false when not present', function() {
+            let thing = checker.for('rando-thing-here');
+
+            assert.ok(!thing.exists());
+          });
+        });
+
+        describe('version', function() {
+          it('can return a bower version', function() {
+            let thing = checker.for('ember', 'bower');
+
+            assert.equal(thing.version, '1.12.1');
+          });
+
+          it('can return a fallback bower version for non-tagged releases', function() {
+            projectRoot.write({
+              bower_components: {
+                ember: buildBowerPackage('ember', '1.13.2', true),
+              },
+            });
+
+            let thing = checker.for('ember', 'bower');
+
+            assert.equal(thing.version, '1.13.2');
+          });
+
+          it('can return a npm version', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.version, '2.0.0');
+          });
+
+          it('does not exist in bower_components', function() {
+            let thing = checker.for('does-not-exist-dummy', 'bower');
+
+            assert.equal(thing.version, null);
+          });
+
+          it('does not exist in nodeModulesPath', function() {
+            let thing = checker.for('does-not-exist-dummy', 'npm');
+
+            assert.equal(thing.version, null);
+          });
+        });
+
+        describe('satisfies', function() {
+          it('returns true if version is included within range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.satisfies('>= 0.0.1'), true);
+          });
+
+          it('returns false if version is not included within range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.satisfies('>= 99.0.0'), false);
+          });
+
+          it('returns false if the dependency does not exist', function() {
+            checker = new VersionChecker(addon);
+            let thing = checker.for('derp', 'npm');
+
+            assert.equal(thing.satisfies('>= 2.9'), false);
+          });
+        });
+
+        describe('isAbove', function() {
+          it('returns true if version is above the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.isAbove('0.0.1'), true);
+          });
+
+          it('returns false if version is below the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.isAbove('99.0.0'), false);
+          });
+
+          it('returns true on beta releases if version is above the specified range', function() {
+            projectRoot.write({
+              bower_components: {
+                ember: buildBowerPackage(
+                  'ember',
+                  '2.3.0-beta.2+41030996',
+                  true
+                ),
+              },
+            });
+
+            let thing = checker.for('ember', 'bower');
+
+            assert.equal(thing.isAbove('2.2.0'), true);
+          });
+
+          it('returns false on beta releases if version is below the specified range', function() {
+            projectRoot.write({
+              bower_components: {
+                ember: buildBowerPackage(
+                  'ember',
+                  '2.3.0-beta.2+41030996',
+                  true
+                ),
+              },
+            });
+
+            let thing = checker.for('ember', 'bower');
+
+            assert.equal(thing.isAbove('2.3.0'), false);
+          });
+
+          it('returns false if the dependency does not exist', function() {
+            checker = new VersionChecker(addon);
+            let thing = checker.for('derpy-herpy', 'npm');
+
+            assert.equal(thing.isAbove('2.9.0'), false);
+          });
+        });
+
+        describe('gt', function() {
+          it('returns true if version is above the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.gt('0.0.1'), true);
+            assert.equal(thing.gt('1.9.9'), true);
+          });
+
+          it('returns false if version is below the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.gt('2.0.0'), false);
+            assert.equal(thing.gt('99.0.0'), false);
+          });
+
+          it('returns false if the dependency does not exist', function() {
+            checker = new VersionChecker(addon);
+            let thing = checker.for('zooeory', 'npm');
+
+            assert.equal(thing.gt('2.9.0'), false);
+          });
+        });
+
+        describe('lt', function() {
+          it('returns false if version is above the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.lt('0.0.1'), false);
+            assert.equal(thing.lt('2.0.0'), false);
+          });
+
+          it('returns true if version is below the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.lt('2.0.1'), true);
+            assert.equal(thing.lt('99.0.0'), true);
+          });
+
+          it('returns false if the dependency does not exist', function() {
+            checker = new VersionChecker(addon);
+            let thing = checker.for('asdfasdf', 'npm');
+
+            assert.equal(thing.lt('2.9.0'), false);
+          });
+        });
+
+        describe('gte', function() {
+          it('returns true if version is above the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.gte('0.0.1'), true);
+            assert.equal(thing.gte('2.0.0'), true);
+          });
+
+          it('returns false if version is below the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.gte('2.0.1'), false);
+            assert.equal(thing.gte('99.0.0'), false);
+          });
+
+          it('returns false if the dependency does not exist', function() {
+            checker = new VersionChecker(addon);
+            let thing = checker.for('hahaha', 'npm');
+
+            assert.equal(thing.gte('2.9.0'), false);
+          });
+        });
+
+        describe('lte', function() {
+          it('returns false if version is above the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.lte('0.0.1'), false);
+            assert.equal(thing.lte('1.9.9'), false);
+          });
+
+          it('returns true if version is below the specified range', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.lte('2.0.0'), true);
+            assert.equal(thing.lte('99.0.0'), true);
+          });
+
+          it('returns false if the dependency does not exist', function() {
+            checker = new VersionChecker(addon);
+            let thing = checker.for('lolz', 'npm');
+
+            assert.equal(thing.lte('2.9.0'), false);
+          });
+        });
+
+        describe('eq', function() {
+          it('returns false if version does not match other version', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.eq('0.0.1'), false);
+            assert.equal(thing.eq('1.9.9'), false);
+            assert.equal(thing.eq('2.0.0-beta.1'), false);
+            assert.equal(thing.eq('2.0.1'), false);
+          });
+
+          it('returns true if version matches other version', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.eq('2.0.0'), true);
+          });
+
+          it('returns false if the dependency does not exist', function() {
+            checker = new VersionChecker(addon);
+            let thing = checker.for('not-here', 'npm');
+
+            assert.equal(thing.eq('2.9.0'), false);
+          });
+        });
+
+        describe('neq', function() {
+          it('returns true if version does not match other version', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.neq('0.0.1'), true);
+            assert.equal(thing.neq('1.9.9'), true);
+            assert.equal(thing.neq('2.0.0-beta.1'), true);
+            assert.equal(thing.neq('2.0.1'), true);
+          });
+
+          it('returns false if version matches other version', function() {
+            let thing = checker.for('ember', 'npm');
+
+            assert.equal(thing.neq('2.0.0'), false);
+          });
+
+          it('returns true if the dependency does not exist', function() {
+            checker = new VersionChecker(addon);
+            let thing = checker.for('not-here', 'npm');
+
+            assert.equal(thing.neq('2.9.0'), true);
+          });
+        });
+
+        describe('assertAbove', function() {
+          it('throws an error with a default message if a matching version was not found', function() {
+            let thing = checker.for('ember', 'npm');
+            let message =
+              'The addon `.*` requires the npm package `ember` to be above 999.0.0, but you have 2.0.0.';
+
+            assert.throws(function() {
+              thing.assertAbove('999.0.0');
+            }, new RegExp(message));
+          });
+
+          it('throws an error with the given message if a matching version was not found', function() {
+            let message =
+              'Must use at least Ember CLI 0.1.2 to use xyz feature';
+            let thing = checker.for('ember', 'npm');
+
+            assert.throws(function() {
+              thing.assertAbove('999.0.0', message);
+            }, new RegExp(message));
+          });
+
+          it('throws a silent error', function() {
+            let message =
+              'Must use at least Ember CLI 0.1.2 to use xyz feature';
+            let thing = checker.for('ember', 'npm');
+
+            assert.throws(
+              function() {
+                thing.assertAbove('999.0.0', message);
+              },
+
+              function(err) {
+                return err.suppressStacktrace;
+              }
+            );
+          });
+        });
       });
     });
-
-    describe('gt', function() {
-      it('returns true if version is above the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.gt('0.0.1'), true);
-        assert.equal(thing.gt('1.9.9'), true);
-      });
-
-      it('returns false if version is below the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.gt('2.0.0'), false);
-        assert.equal(thing.gt('99.0.0'), false);
-      });
-
-      it('returns false if the dependency does not exist', function() {
-        checker = new VersionChecker(addon);
-        let thing = checker.for('zooeory', 'npm');
-
-        assert.equal(thing.gt('2.9.0'), false);
-      });
-    });
-
-    describe('lt', function() {
-      it('returns false if version is above the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.lt('0.0.1'), false);
-        assert.equal(thing.lt('2.0.0'), false);
-      });
-
-      it('returns true if version is below the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.lt('2.0.1'), true);
-        assert.equal(thing.lt('99.0.0'), true);
-      });
-
-      it('returns false if the dependency does not exist', function() {
-        checker = new VersionChecker(addon);
-        let thing = checker.for('asdfasdf', 'npm');
-
-        assert.equal(thing.lt('2.9.0'), false);
-      });
-    });
-
-    describe('gte', function() {
-      it('returns true if version is above the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.gte('0.0.1'), true);
-        assert.equal(thing.gte('2.0.0'), true);
-      });
-
-      it('returns false if version is below the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.gte('2.0.1'), false);
-        assert.equal(thing.gte('99.0.0'), false);
-      });
-
-      it('returns false if the dependency does not exist', function() {
-        checker = new VersionChecker(addon);
-        let thing = checker.for('hahaha', 'npm');
-
-        assert.equal(thing.gte('2.9.0'), false);
-      });
-    });
-
-    describe('lte', function() {
-      it('returns false if version is above the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.lte('0.0.1'), false);
-        assert.equal(thing.lte('1.9.9'), false);
-      });
-
-      it('returns true if version is below the specified range', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.lte('2.0.0'), true);
-        assert.equal(thing.lte('99.0.0'), true);
-      });
-
-      it('returns false if the dependency does not exist', function() {
-        checker = new VersionChecker(addon);
-        let thing = checker.for('lolz', 'npm');
-
-        assert.equal(thing.lte('2.9.0'), false);
-      });
-    });
-
-    describe('eq', function() {
-      it('returns false if version does not match other version', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.eq('0.0.1'), false);
-        assert.equal(thing.eq('1.9.9'), false);
-        assert.equal(thing.eq('2.0.0-beta.1'), false);
-        assert.equal(thing.eq('2.0.1'), false);
-      });
-
-      it('returns true if version matches other version', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.eq('2.0.0'), true);
-      });
-
-      it('returns false if the dependency does not exist', function() {
-        checker = new VersionChecker(addon);
-        let thing = checker.for('not-here', 'npm');
-
-        assert.equal(thing.eq('2.9.0'), false);
-      });
-    });
-
-    describe('neq', function() {
-      it('returns true if version does not match other version', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.neq('0.0.1'), true);
-        assert.equal(thing.neq('1.9.9'), true);
-        assert.equal(thing.neq('2.0.0-beta.1'), true);
-        assert.equal(thing.neq('2.0.1'), true);
-      });
-
-      it('returns false if version matches other version', function() {
-        let thing = checker.for('ember', 'npm');
-
-        assert.equal(thing.neq('2.0.0'), false);
-      });
-
-      it('returns true if the dependency does not exist', function() {
-        checker = new VersionChecker(addon);
-        let thing = checker.for('not-here', 'npm');
-
-        assert.equal(thing.neq('2.9.0'), true);
-      });
-    });
-
-    describe('assertAbove', function() {
-      it('throws an error with a default message if a matching version was not found', function() {
-        let thing = checker.for('ember', 'npm');
-        let message =
-          'The addon `fake-addon` requires the npm package `ember` to be above 999.0.0, but you have 2.0.0.';
-
-        assert.throws(function() {
-          thing.assertAbove('999.0.0');
-        }, new RegExp(message));
-      });
-
-      it('throws an error with the given message if a matching version was not found', function() {
-        let message = 'Must use at least Ember CLI 0.1.2 to use xyz feature';
-        let thing = checker.for('ember', 'npm');
-
-        assert.throws(function() {
-          thing.assertAbove('999.0.0', message);
-        }, new RegExp(message));
-      });
-
-      it('throws a silent error', function() {
-        let message = 'Must use at least Ember CLI 0.1.2 to use xyz feature';
-        let thing = checker.for('ember', 'npm');
-
-        assert.throws(
-          function() {
-            thing.assertAbove('999.0.0', message);
-          },
-
-          function(err) {
-            return err.suppressStacktrace;
-          }
-        );
-      });
-    });
-  });
+  }
 });


### PR DESCRIPTION
There are two main use cases for VersionChecker today:

1. Checking the version of an NPM dependency of an Addon
2. Checking the version of an NPM _or_ Bower dependency of the root Project

These use cases are currently intermingled in the VersionChecker API, which causes some confusing behavior:

1. **When passing an Addon to a VersionChecker:**
    * Checking an NPM dependency will check the addon's `package.json` directly, but checking a Bower dependency will check the root Project's `bower.json`. There is no way to check the root Project's NPM dependencies.

    * Attempting to use `forEmber` will attempt to check the _Addon's_ version of `ember-source` (which shouldn't exist), and if it is not found will attempt to check the Bower dependencies of the root Project. This forking of behavior is confusing because it correctly detects the version of Ember for users who are still using Bower, but will not for users who switch to `ember-source`. 

      The "fix" for this is to use `_findHost` to find the root EmberApp and to pass that to VersionChecker instead, but this breaks as described below and is still confusing (why can I even call `forEmber` on a VersionChecker for a parent addon when it has this behavior?)

3. **When passing a Project to a VersionChecker:** 
    * It will error because the Bower checker assumes that it will receive an item with a `project` property which is a Project.

4. **When passing an EmberApp to a VersionChecker:** 
    * It will attempt to check NPM dependencies using an `undefined` root, but will correctly check Bower dependencies. This generally works, but breaks when using `yarn link` because NPM's module resolution defaults to the addon which is using VersionChecker rather than the Project root.

This PR proposes that we should clarify the API by enforcing that users explicitly pass the thing they are trying to check the version of, either an Addon or a root Project, to VersionChecker:

```js
included(parent) {
  this._super.included.apply(this, arguments);

  // Currently the only meaningful way to check if the parent is an Addon or an EmberApp
  if (parent.root !== undefined) {
    let parentAddonChecker = new VersionChecker(parent);
  
    parentAddonChecker.forEmber(); // Should throw an error, doesn't make sense
    parentAddonChecker.for('foo', 'bower'); // Should throw an error, doesn't make sense
    parentAddonChecker.for('foo', 'npm'); // allowed
  }

  let rootVersionChecker = new VersionChecker(this.project);

  parentAddonChecker.forEmber(); // allowed
  parentAddonChecker.for('foo', 'bower'); // allowed
  parentAddonChecker.for('foo', 'npm'); // allowed
}
```

We would do this by first allowing VersionChecker to accept a Project directly (as this PR does), adding deprecations, and allowing users to switch over to the new usage style, then creating a new major version.