### PR TITLE
[feat] Adds `projectNpm` as a source

### DIFF
--- a/src/dependency-version-checker.js
+++ b/src/dependency-version-checker.js
@@ -51,9 +51,11 @@ class DependencyVersionChecker {
     let message = _message;
 
     if (!message) {
-      message = `The addon \`${this._parent._addon.name}\` requires the ${this
-        ._type} package \`${this
-        .name}\` to be above ${compareVersion}, but you have ${this.version}.`;
+      message = `The addon \`${this._parent._addon.name}\` requires the ${
+        this._type
+      } package \`${this.name}\` to be above ${compareVersion}, but you have ${
+        this.version
+      }.`;
     }
 
     if (!this.isAbove(compareVersion)) {

--- a/src/npm-dependency-version-checker.js
+++ b/src/npm-dependency-version-checker.js
@@ -4,15 +4,34 @@ const resolve = require('resolve');
 const DependencyVersionChecker = require('./dependency-version-checker');
 
 class NPMDependencyVersionChecker extends DependencyVersionChecker {
-  constructor(parent, name) {
+  constructor(parent, name, useProject) {
     super(parent, name);
 
     let addon = this._parent._addon;
+    let root;
+
+    if (useProject === true) {
+      // User passed in `projectNpm`, so we want to use the project root
+      root = addon.project.root;
+    } else if (addon.root) {
+      // User passed in `npm`, so we want to use the parent addon's root if it exists
+      root = addon.root;
+    } else if (addon.project) {
+      // Parent addon's root doesn't exist, so the parent is an EmberAddon or
+      // EmberApp. Use the project's root instead.
+      root = addon.project.root;
+    } else {
+      throw new Error(
+        `ember-cli-version-checker could not find NPM package root for ${
+          this.name
+        }, did you pass an Addon or EmberApp/EmberAddon?`
+      );
+    }
 
     let jsonPath;
     try {
       jsonPath = resolve.sync(this.name + '/package.json', {
-        basedir: addon.root,
+        basedir: root,
       });
     } catch (e) {
       if (e.code === 'MODULE_NOT_FOUND') {
@@ -23,7 +42,7 @@ class NPMDependencyVersionChecker extends DependencyVersionChecker {
     }
 
     this._jsonPath = jsonPath;
-    this._type = 'npm';
+    this._type = useProject ? 'project npm' : 'npm';
   }
 }
 

--- a/src/version-checker.js
+++ b/src/version-checker.js
@@ -13,13 +13,15 @@ class VersionChecker {
   for(name, type) {
     if (type === 'bower') {
       return new BowerDependencyVersionChecker(this, name);
+    } else if (type === 'projectNpm') {
+      return new NPMDependencyVersionChecker(this, name, true);
     } else {
       return new NPMDependencyVersionChecker(this, name);
     }
   }
 
   forEmber() {
-    let emberVersionChecker = this.for('ember-source', 'npm');
+    let emberVersionChecker = this.for('ember-source', 'projectNpm');
 
     if (emberVersionChecker.version) {
       return emberVersionChecker;

--- a/tests/index.js
+++ b/tests/index.js
@@ -82,6 +82,19 @@ describe('ember-cli-version-checker', function() {
         let thing = checker.forEmber();
         assert.equal(thing.version, '2.10.0');
       });
+
+      it('returns the project ember-source version even if an addon ember-source version exists (linking)', function() {
+        projectContents.node_modules['fake-addon'] = {
+          node_modules: {
+            'ember-source': buildPackage('ember-source', '3.1.0'),
+          },
+        };
+
+        projectRoot.write(projectContents);
+
+        let thing = checker.forEmber();
+        assert.equal(thing.version, '2.10.0');
+      });
     });
   });
 
@@ -130,6 +143,21 @@ describe('ember-cli-version-checker', function() {
     describe('specified type', function() {
       it('defaults to `npm`', function() {
         let thing = checker.for('ember');
+
+        assert.equal(thing.version, '2.0.0');
+      });
+
+      it('allows `projectNpm`', function() {
+        projectRoot.write({
+          node_modules: {
+            'fake-addon': {
+              node_modules: {
+                ember: buildPackage('ember', '3.0.0'),
+              },
+            },
+          },
+        });
+        let thing = checker.for('ember', 'projectNpm');
 
         assert.equal(thing.version, '2.0.0');
       });


### PR DESCRIPTION
Currently, when using `forEmber` we are always looking for a project level version, but we first attempt to check the addon's own dependencies. When linking addons in development or in Lerna repos, this breaks because the addons will have their own version of `ember-source` installed, and the VersionChecker will default to that version instead of resolving the project's root version.

This problem applies to peer dependencies in general, and can cause surprising failures, particularly when a project is switching from Bower to NPM. Adding a `projectNpm` "location" to the version checker prevents this ambiguity from arising in the first place since we explicitly ask for dependencies at the project level or the local level. This also allows us to maintain a unified, simple API for all use-cases:

```js

included(parent) {
  checker = new VersionChecker(parent);

  // Check the immediate parent's version of 'foo', always works even
  // if the immediate parent is the root project
  checker.for('foo', 'npm');

  // Check the root project's version of 'foo', no need to create a
  // second checker or use `_findHost`
  checker.for('foo', 'projectNpm');

  checker.forEmber(); // Always correct, even with linking
}
```

Supercedes #51 