### PR TITLE
Support resolution with Yarn PnP.

### DIFF
--- a/src/npm-dependency-version-checker.js
+++ b/src/npm-dependency-version-checker.js
@@ -33,6 +33,9 @@ class NPMDependencyVersionChecker extends DependencyVersionChecker {
     let jsonPath;
 
     try {
+      // the custom `pnp` code here can be removed when yarn 1.13 is the
+      // current release this is due to Yarn 1.13 and resolve interoperating
+      // together seemlessly
       jsonPath = pnp
         ? pnp.resolveToUnqualified(target, basedir)
         : resolve.sync(target, { basedir });

--- a/tests/index.js
+++ b/tests/index.js
@@ -56,6 +56,12 @@ describe('ember-cli-version-checker', function() {
     })
   );
 
+  afterEach(
+    co.wrap(function*() {
+      yield projectRoot.dispose();
+    })
+  );
+
   for (let scenario of ['addon', 'project']) {
     describe(`with ${scenario}`, function() {
       let FakeClass = scenario === 'addon' ? FakeAddon : FakeProject;

--- a/tests/index.js
+++ b/tests/index.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const VersionChecker = require('..');
 const co = require('co');
 const execSync = require('child_process').execSync;
+const semver = require('semver');
 
 const createTempDir = require('broccoli-test-helper').createTempDir;
 const ROOT = process.cwd();
@@ -479,59 +480,61 @@ describe('ember-cli-version-checker', function() {
     });
   }
 
-  describe('with yarn pnp', function() {
-    this.timeout(600000);
+  if (semver.gte(process.versions.node, '8.0.0')) {
+    describe('with yarn pnp', function() {
+      this.timeout(600000);
 
-    beforeEach(function() {
-      process.chdir(projectRoot.path());
+      beforeEach(function() {
+        process.chdir(projectRoot.path());
 
-      projectRoot.write({
-        'package.json': JSON.stringify({
-          private: true,
-          name: 'test-project',
-          version: '0.0.0',
-          dependencies: {
-            'ember-source-channel-url': '1.1.0',
-            'ember-cli-version-checker': `link:${ROOT}`,
-          },
-          installConfig: {
-            pnp: true,
-          },
-        }),
-        'index.js': `
-const VersionChecker = require('ember-cli-version-checker');
+        projectRoot.write({
+          'package.json': JSON.stringify({
+            private: true,
+            name: 'test-project',
+            version: '0.0.0',
+            dependencies: {
+              'ember-source-channel-url': '1.1.0',
+              'ember-cli-version-checker': `link:${ROOT}`,
+            },
+            installConfig: {
+              pnp: true,
+            },
+          }),
+          'index.js': `
+  const VersionChecker = require('ember-cli-version-checker');
 
-let checker = new VersionChecker({
-  root: process.cwd(),
-  isEmberCLIProject() {},
-});
+  let checker = new VersionChecker({
+    root: process.cwd(),
+    isEmberCLIProject() {},
+  });
 
-let dep = checker.for(process.argv[2]);
-console.log(process.argv[2] + ': ' + dep.version);`,
+  let dep = checker.for(process.argv[2]);
+  console.log(process.argv[2] + ': ' + dep.version);`,
+        });
+
+        execSync('yarn');
       });
 
-      execSync('yarn');
+      afterEach(function() {
+        process.chdir(ROOT);
+      });
+
+      it('finds packages that are present', function() {
+        let result = execSync(
+          'node -r ./.pnp.js ./index.js ember-source-channel-url'
+        );
+
+        assert.strictEqual(
+          result.toString(),
+          'ember-source-channel-url: 1.1.0\n'
+        );
+      });
+
+      it('does not find packages that are missing', function() {
+        let result = execSync('node -r ./.pnp.js ./index.js blah-blah-blah');
+
+        assert.strictEqual(result.toString(), 'blah-blah-blah: undefined\n');
+      });
     });
-
-    afterEach(function() {
-      process.chdir(ROOT);
-    });
-
-    it('finds packages that are present', function() {
-      let result = execSync(
-        'node -r ./.pnp.js ./index.js ember-source-channel-url'
-      );
-
-      assert.strictEqual(
-        result.toString(),
-        'ember-source-channel-url: 1.1.0\n'
-      );
-    });
-
-    it('does not find packages that are missing', function() {
-      let result = execSync('node -r ./.pnp.js ./index.js blah-blah-blah');
-
-      assert.strictEqual(result.toString(), 'blah-blah-blah: undefined\n');
-    });
-  });
+  }
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,8 +5,10 @@
 const assert = require('assert');
 const VersionChecker = require('..');
 const co = require('co');
+const execSync = require('child_process').execSync;
 
 const createTempDir = require('broccoli-test-helper').createTempDir;
+const ROOT = process.cwd();
 
 function buildPackageJSON(name, version) {
   return `{
@@ -476,4 +478,60 @@ describe('ember-cli-version-checker', function() {
       });
     });
   }
+
+  describe('with yarn pnp', function() {
+    this.timeout(600000);
+
+    beforeEach(function() {
+      process.chdir(projectRoot.path());
+
+      projectRoot.write({
+        'package.json': JSON.stringify({
+          private: true,
+          name: 'test-project',
+          version: '0.0.0',
+          dependencies: {
+            'ember-source-channel-url': '1.1.0',
+            'ember-cli-version-checker': `link:${ROOT}`,
+          },
+          installConfig: {
+            pnp: true,
+          },
+        }),
+        'index.js': `
+const VersionChecker = require('ember-cli-version-checker');
+
+let checker = new VersionChecker({
+  root: process.cwd(),
+  isEmberCLIProject() {},
+});
+
+let dep = checker.for(process.argv[2]);
+console.log(process.argv[2] + ': ' + dep.version);`,
+      });
+
+      execSync('yarn');
+    });
+
+    afterEach(function() {
+      process.chdir(ROOT);
+    });
+
+    it('finds packages that are present', function() {
+      let result = execSync(
+        'node -r ./.pnp.js ./index.js ember-source-channel-url'
+      );
+
+      assert.strictEqual(
+        result.toString(),
+        'ember-source-channel-url: 1.1.0\n'
+      );
+    });
+
+    it('does not find packages that are missing', function() {
+      let result = execSync('node -r ./.pnp.js ./index.js blah-blah-blah');
+
+      assert.strictEqual(result.toString(), 'blah-blah-blah: undefined\n');
+    });
+  });
 });


### PR DESCRIPTION
Yarn 1.12.x supports the new PnP system to allow folks to avoid having a `node_modules/` folder in _each_ project. To implement this, they create a static file mapping table for each package and then require them directly from the global Yarn cache.

Since a PnP project is no longer following the "normal" node module resolution rules changes were needed in the `resolve` package. Those changes landed in `resolve@1.9.0` and are leveraged by Yarn 1.13.0+.

In the mean time (throughout the Yarn 1.12.x lifespan), a simple `resolve.sync` isn't quite good enough so we now detect if we are running in a PnP scenario (by attempting to require the `pnpapi` module). If we are, we use the public API provided by Yarn's `pnpapi` module to resolve the package being checked for relative to the provided root.

Fixes #78.
Related to https://github.com/ember-cli/ember-cli/issues/8164.