### PR TITLE
chore(ci): Install latest yarn via apt-get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ cache:
   yarn: true
 
 
+before_install:
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn
+  - yarn --version
+
 install:
   - yarn install --no-lockfile
 


### PR DESCRIPTION
Based on instructions from:

https://yarnpkg.com/lang/en/docs/install-ci/