### PR TITLE
chore(ci): install yarn via curl :weary:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
   - "10"
   - "11"
 
+dist: xenial
+
 cache:
   yarn: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ cache:
 
 
 before_install:
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3
+  - export PATH="$HOME/.yarn/bin:$PATH"
   - yarn --version
 
 install:


### PR DESCRIPTION
Installing via apt-get (as suggested by yarnpkg.com) does not work, because the Travis build images preinstall `yarn` and install it on `$PATH` _before_ whereever `apt-get` installs it.