### PR TITLE
Perf fix: cache the resolutions identically to how require does.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
   },
   "scripts": {
     "test": "mocha tests",
+    "test:debug": "mocha debug tests",
     "changelog": "lerna-changelog"
   },
   "dependencies": {
-    "resolve": "^1.10.0",
+    "resolve-package-path": "^1.0.6",
     "semver": "^5.6.0"
   },
   "devDependencies": {

--- a/src/npm-dependency-version-checker.js
+++ b/src/npm-dependency-version-checker.js
@@ -1,56 +1,16 @@
 'use strict';
 
-const resolve = require('resolve');
 const DependencyVersionChecker = require('./dependency-version-checker');
 const getProject = require('./get-project');
+const resolvePackage = require('resolve-package-path');
 
-const ALLOWED_ERROR_CODES = [
-  // resolve package error codes
-  'MODULE_NOT_FOUND',
-
-  // Yarn PnP Error Codes
-  'UNDECLARED_DEPENDENCY',
-  'MISSING_PEER_DEPENDENCY',
-  'MISSING_DEPENDENCY',
-];
-
-let pnp;
-
-try {
-  pnp = require('pnpapi');
-} catch (error) {
-  // not in Yarn PnP; not a problem
-}
-
-class NPMDependencyVersionChecker extends DependencyVersionChecker {
+module.exports = class NPMDependencyVersionChecker extends DependencyVersionChecker {
   constructor(parent, name) {
     super(parent, name);
 
     let addon = this._parent._addon;
-
-    let target = this.name + '/package.json';
     let basedir = addon.root || getProject(addon).root;
-
-    let jsonPath;
-
-    try {
-      // the custom `pnp` code here can be removed when yarn 1.13 is the
-      // current release this is due to Yarn 1.13 and resolve interoperating
-      // together seemlessly
-      jsonPath = pnp
-        ? pnp.resolveToUnqualified(target, basedir)
-        : resolve.sync(target, { basedir });
-    } catch (e) {
-      if (ALLOWED_ERROR_CODES.includes(e.code)) {
-        jsonPath = null;
-      } else {
-        throw e;
-      }
-    }
-
-    this._jsonPath = jsonPath;
+    this._jsonPath = resolvePackage(this.name, basedir);
     this._type = 'npm';
   }
-}
-
-module.exports = NPMDependencyVersionChecker;
+};

--- a/tests/index.js
+++ b/tests/index.js
@@ -203,7 +203,6 @@ describe('ember-cli-version-checker', function() {
         describe('exists', function() {
           it('returns true when present', function() {
             let thing = checker.for('ember');
-
             assert.ok(thing.exists());
           });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2295,6 +2295,18 @@ path-posix@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-posix/-/path-posix-1.0.0.tgz#06b26113f56beab042545a23bfa88003ccac260f"
   integrity sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=
 
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+  integrity sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
+  dependencies:
+    path-root-regex "^0.1.0"
+
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
@@ -2474,6 +2486,14 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
   integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
+
+resolve-package-path@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-1.0.6.tgz#f896025539246d99cf218926a14d704a99935a3f"
+  integrity sha512-hhn+IJ8KrfoxlXrWnh6tmsNL1jeHO6IEK79vRvS8fCBbe8i06bP+Iag6NzT4XXfozeUbxKtadg6pWKMlfJVgNQ==
+  dependencies:
+    path-root "^0.1.1"
+    resolve "^1.10.0"
 
 resolve-path@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Turns out this is extremely expensive, and apps with many
apps/engines/in-repo addons spend up to minutes here.

We should discuss better/improved/ideal solutions, i don't like this approach really, and we keep playing wack-a-mole with similar solutions anytime we use require.resolve....

 But this is worth a discussion, as this approach really does save ALOT (for very large apps, minutes) of startup time.