### PR TITLE
Fix lint

### DIFF
--- a/src/dependency-version-checker.js
+++ b/src/dependency-version-checker.js
@@ -51,11 +51,7 @@ class DependencyVersionChecker {
     let message = _message;
 
     if (!message) {
-      message = `The addon \`${this._parent._addon.name}\` requires the ${
-        this._type
-      } package \`${this.name}\` to be above ${compareVersion}, but you have ${
-        this.version
-      }.`;
+      message = `The addon \`${this._parent._addon.name}\` requires the ${this._type} package \`${this.name}\` to be above ${compareVersion}, but you have ${this.version}.`;
     }
 
     if (!this.isAbove(compareVersion)) {


### PR DESCRIPTION
Ran `prettier src/* --write` to fix CI error:
```
  1) eslint
       should have no errors in src:
     Error: Code did not pass lint rules
src/dependency-version-checker.js
  54:75  error  Replace `⏎········this._type⏎······}·package·\`${this.name}\`·to·be·above·${compareVersion},·but·you·have·${⏎········this.version⏎······` with `this._type}·package·\`${this.name}\`·to·be·above·${compareVersion},·but·you·have·${this.version`  prettier/prettier
✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
      at Context.<anonymous> (node_modules/mocha-eslint/index.js:36:15)
```