### PR TITLE
Fix hasSingleImplementation

### DIFF
--- a/src/utils/single-implementation.js
+++ b/src/utils/single-implementation.js
@@ -22,7 +22,7 @@ function hasSingleImplementation(targetName, project) {
 
   for (let { name, root } of allAddons(project)) {
     if (targetName === name) {
-      if (lastRoot !== undefined) {
+      if (lastRoot !== undefined && lastRoot !== root) {
         map.set(targetName, false);
         return false;
       } else {

--- a/tests/index-tests.js
+++ b/tests/index-tests.js
@@ -439,11 +439,17 @@ describe('ember-cli-version-checker', function() {
                 addons: [
                   {
                     name: 'foo',
-                    root: 'node_modules/fake-addon/node_modeuls/foo',
+                    root: 'node_modules/fake-addon/node_modules/foo',
                   },
                   {
                     name: 'bar',
                     root: 'node_modules/fake-addon/node_modules/bar',
+                    addons: [
+                      {
+                        name: 'foo',
+                        root: 'node_modules/fake-addon/node_modules/foo',
+                      },
+                    ],
                   },
                 ],
               },
@@ -477,7 +483,7 @@ describe('ember-cli-version-checker', function() {
           });
 
           it('has a working #filterAddonsByName', () => {
-            assert.equal(checker.filterAddonsByName('foo').length, 1);
+            assert.equal(checker.filterAddonsByName('foo').length, 2);
             assert.equal(checker.filterAddonsByName('top').length, 1);
             assert.equal(checker.filterAddonsByName('bar').length, 2);
             assert.equal(
@@ -498,7 +504,7 @@ describe('ember-cli-version-checker', function() {
           it('has a functioning allAddons iterator', function() {
             assert.deepEqual(
               [...checker.allAddons()].map(x => x.name),
-              ['top', 'bar', 'fake-addon', 'foo', 'bar']
+              ['top', 'bar', 'fake-addon', 'foo', 'bar', 'foo']
             );
           });
         });


### PR DESCRIPTION
```
it('#hasSingleImplementation detects singleton', function() {
  assert.ok(checker.hasSingleImplementation('foo'));
```
will fail without the fix in place