### PR TITLE
Add ProjectWideDependencyChecker `check` API

### DIFF
--- a/tests/utils/addon.js
+++ b/tests/utils/addon.js
@@ -4,5 +4,7 @@ module.exports = class Addon extends require('./has-a-fixture') {
   constructor(name, version, project, fixture) {
     super(name, version, fixture);
     this.project = project;
+
+    Object.freeze(this);
   }
 };

--- a/tests/utils/has-a-fixture.js
+++ b/tests/utils/has-a-fixture.js
@@ -1,11 +1,40 @@
 'use strict';
 
+// Create a strict "fake" ember-cli addon
+class FakeEmberAddon {
+  constructor(addon) {
+    this._addon = addon;
+    Object.freeze(this);
+  }
+
+  get addons() {
+    return this._addon.addons;
+  }
+
+  get name() {
+    return this._addon.name;
+  }
+
+  get version() {
+    return this._addon.version;
+  }
+
+  get pkg() {
+    return this._addon._fixture.pkg;
+  }
+
+  get root() {
+    return this._addon.root;
+  }
+}
+
 // abstract
 module.exports = class HasAFixture {
   constructor(name, version, fixture) {
     this._fixture = fixture;
     this.name = name;
     this.version = version;
+    this.addons = [];
   }
 
   get root() {
@@ -32,10 +61,14 @@ module.exports = class HasAFixture {
     let addon;
     this._fixture.addDependency(name, version, fixture => {
       addon = new (require('./addon'))(name, version, this, fixture);
+
       if (typeof cb === 'function') {
         cb(addon);
       }
     });
+
+    this.addons.push(new FakeEmberAddon(addon));
+
     return addon;
   }
 
@@ -47,6 +80,7 @@ module.exports = class HasAFixture {
         cb(addon);
       }
     });
+    this.addons.push(new FakeEmberAddon(addon));
     return addon;
   }
 

--- a/tests/utils/project.js
+++ b/tests/utils/project.js
@@ -6,6 +6,7 @@ module.exports = class Project extends require('./has-a-fixture') {
     super(name, version, new FixturifyProject(name, version));
     this.version = version;
     this._addonsInitialized = true;
+    Object.freeze(this);
   }
   isEmberCLIProject() {}
 };


### PR DESCRIPTION
Add ProjectWideDependencyChecker `check` API

This allows someone to make broader assertions against the project’s dependencies. The goal here is to handle the complexity of making these assertions here in ember-cli-version-checker.

* no extra disk IO, all addon lookup goes through ember-cli's public APIs and ensures to only utilizes pathways that use ember-cli's authentication
* good default errors
* provides a layered API that allows the end user to run checks, but constraint their own rollup if needed.

Example:

```js
const checker VersionChecker.forProject(project);

checker.check({
  ‘ember-data’: ‘>= 3.16.0’,
  ‘ember-resolver’: ‘*’,
}) === {
  /* typically what people want */
  isSatisfied: true | false,
  message: ‘’ || ‘useful canned error message’,
  
 /* checker.check(...).assert() will throw a canned error response */

 /* checker.check(...).assert(description) will throw a canned error response but with a custom description */
  assert(description?) { } 

  /* deeper details for power users*/
  node_modules: {
   ‘ember-data’: {
     isSatisfied: true | false,
     message: ‘’ || ‘useful canned error message’,
     versions: [/* list of versions found */]
   }, 
   ‘ember-resolver': { /* basically same as ember-datas blob, but for the results of ember-resolver */ },
  }
}
```

This Commit also fixes/cleans up the testing infrastructure to simplify the testing of the above new feature

--- 

TODO: 

- [x] Update readme
- [x] ensure this meets our needs etc
- [x] add missing unit test for `filterAddonsByNames` for good measure