### PR TITLE
fix: Semver constraint matching should allow prereleases

### DIFF
--- a/src/project-wide-dependency-checker.js
+++ b/src/project-wide-dependency-checker.js
@@ -108,7 +108,9 @@ module.exports = class ProjectWideDependencyChecker {
       const missing = versions.length === 0;
       const isSatisfied =
         !missing &&
-        versions.every(version => semver.satisfies(version, constraint, { includePrerelease: true }));
+        versions.every(version =>
+          semver.satisfies(version, constraint, { includePrerelease: true })
+        );
 
       let message;
       if (isSatisfied) {

--- a/src/project-wide-dependency-checker.js
+++ b/src/project-wide-dependency-checker.js
@@ -108,7 +108,7 @@ module.exports = class ProjectWideDependencyChecker {
       const missing = versions.length === 0;
       const isSatisfied =
         !missing &&
-        versions.every(version => semver.satisfies(version, constraint));
+        versions.every(version => semver.satisfies(version, constraint, { includePrerelease: true }));
 
       let message;
       if (isSatisfied) {


### PR DESCRIPTION
Without this flag `3.20.0-alpha.1` does not satisfy `>= 3.19.0`
See https://www.npmjs.com/package/semver#prerelease-tags for docs