### PR TITLE
Add isAtOrAbove and assertAtOrAbove

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ module.exports = {
 
 ### assertAbove
 
-Throws an error with the given message if a minimum version isn't met.
+Throws an error if the package version is not greater than the given version.
+You can also provide a specific message as the third argument if you'd like to
+customize the output.
 
 ```javascript
 let VersionChecker = require('ember-cli-version-checker');
@@ -73,11 +75,16 @@ module.exports = {
     let checker = new VersionChecker(this.project);
 
     checker.for('ember-cli').assertAbove('2.0.0');
+    checker.for('ember-cli').assertAbove('2.0.0', 'To use awesome-addon you must have ember-cli 2.0.1');
   }
 };
 ```
 
-You can also provide a specific message as the third argument to `assertAbove` if you'd like to customize the output.
+### assertAtOrAbove
+
+Throws an error if the package version is not greater than or equal to the
+given (minimum) version. You can also provide a specific message as the third
+argument if you'd like to customize the output.
 
 ```javascript
 let VersionChecker = require('ember-cli-version-checker');
@@ -89,14 +96,15 @@ module.exports = {
 
     let checker = new VersionChecker(this.project);
 
-    checker.for('ember-cli').assertAbove('2.0.0', 'To use awesome-addon you must have ember-cli 2.0.0');
+    checker.for('ember-cli').assertAtOrAbove('2.0.0');
+    checker.for('ember-cli').assertAtOrAbove('2.0.0', 'To use awesome-addon you must have ember-cli 2.0.0');
   }
 };
 ```
 
 ### isAbove
 
-Returns `true` if the packages version is above the specified comparison range.
+Returns `true` if the package version is greater than the specified comparison version.
 
 ```javascript
 let VersionChecker = require('ember-cli-version-checker');
@@ -110,6 +118,30 @@ module.exports = {
     let dep = checker.for('ember-cli');
 
     if (dep.isAbove('2.0.0')) {
+      /* deal with 2.0.1 stuff */
+    } else {
+      /* provide backwards compat */
+    };
+  }
+};
+```
+
+### isAtOrAbove
+
+Returns `true` if the package version is greater than or equal to the specified comparison version.
+
+```javascript
+let VersionChecker = require('ember-cli-version-checker');
+
+module.exports = {
+  name: 'awesome-addon',
+  init() {
+    this._super.init.apply(this, arguments);
+
+    let checker = new VersionChecker(this.project);
+    let dep = checker.for('ember-cli');
+
+    if (dep.isAtOrAbove('2.0.0')) {
       /* deal with 2.0.0 stuff */
     } else {
       /* provide backwards compat */

--- a/src/dependency-version-checker.js
+++ b/src/dependency-version-checker.js
@@ -63,12 +63,30 @@ class DependencyVersionChecker {
     return semver.gt(this.version, compareVersion);
   }
 
+  isAtOrAbove(compareVersion) {
+    if (!this.version) {
+      return false;
+    }
+    return semver.gte(this.version, compareVersion);
+  }
+
   assertAbove(compareVersion, _message) {
     let message = _message;
     if (!this.isAbove(compareVersion)) {
       if (!message) {
         const parentAddon = this._parent._addon;
         message = `The addon \`${parentAddon.name}\` @ \`${parentAddon.root}\` requires the npm package \`${this.name}\` to be above ${compareVersion}, but you have ${this.version}.`;
+      }
+      throw new Error(message);
+    }
+  }
+
+  assertAtOrAbove(compareVersion, _message) {
+    let message = _message;
+    if (!this.isAtOrAbove(compareVersion)) {
+      if (!message) {
+        const parentAddon = this._parent._addon;
+        message = `The addon \`${parentAddon.name}\` @ \`${parentAddon.root}\` requires the npm package \`${this.name}\` to be at or above ${compareVersion}, but you have ${this.version}.`;
       }
       throw new Error(message);
     }

--- a/tests/index-tests.js
+++ b/tests/index-tests.js
@@ -295,6 +295,47 @@ describe('ember-cli-version-checker', function() {
           thing.assertAbove('999.0.0', message);
         }, new RegExp(message));
       });
+
+      it('throws an error with a default message if versions match', function() {
+        let thing = checker.for('ember', 'npm');
+        let message =
+          'The addon `.*` requires the npm package `ember` to be above 2.0.0, but you have 2.0.0.';
+
+        assert.throws(() => {
+          thing.assertAbove('2.0.0');
+        }, new RegExp(message));
+      });
+    });
+
+    describe('assertAtOrAbove', function() {
+      it('throws an error with a default message if a matching version was not found', function() {
+        let thing = checker.for('ember', 'npm');
+        let message =
+          'The addon `.*` requires the npm package `ember` to be at or above 999.0.0, but you have 2.0.0.';
+
+        assert.throws(() => {
+          thing.assertAtOrAbove('999.0.0');
+        }, new RegExp(message));
+      });
+
+      it('throws an error with the given message if a matching version was not found', function() {
+        let message = 'Must use at least Ember CLI 0.1.2 to use xyz feature';
+        let thing = checker.for('ember', 'npm');
+
+        assert.throws(() => {
+          thing.assertAtOrAbove('999.0.0', message);
+        }, new RegExp(message));
+      });
+
+      it('does not throw an error with a default message if versions match', function() {
+        let thing = checker.for('ember', 'npm');
+        let message =
+          'The addon `.*` requires the npm package `ember` to be at or above 2.0.0, but you have 2.0.0.';
+
+        assert.doesNotThrow(() => {
+          thing.assertAtOrAbove('2.0.0');
+        }, new RegExp(message));
+      });
     });
   });
 });


### PR DESCRIPTION
Currently the `assertAbove()` function is [incorrectly documented as a way to check for a minimum version](https://github.com/ember-cli/ember-cli-version-checker/blob/v5.1.2/README.md#assertabove) and is actually a [footgun if used in this way](https://github.com/ember-cli/ember-cli-version-checker/issues/16). (Ask me how I know... LOL)

> Throws an error with the given message if a minimum version isn't met.

Instead, you must specify the version _prior_ to the minimum version you are concerned about. This can also become an issue if there is a patch version of the prior version, which would then be unexpectedly accepted by the check. Ex: Ember Octane (v3.15) is the "true" minimum version, so you `assertAbove('3.14.2')`, but then v3.14.3 comes out...

This PR clarifies the documentation for `assertAbove()` and `isAbove()` but also adds `assertAtOrAbove()` and `isAtOrAbove()`, with documentation and testing. Basically the difference between the two is `gt()` vs `gte()`. 