### PR TITLE
Bump semver to ^7.5.3 to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-version-checker",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Determine if your addon is being used by a minimum version of Ember CLI.",
   "homepage": "https://github.com/ember-cli/ember-cli-version-checker",
   "bugs": {
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "resolve-package-path": "^3.1.0",
-    "semver": "^7.3.4",
+    "semver": "^7.5.3",
     "silent-error": "^1.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,6 +3094,13 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"


### PR DESCRIPTION
The current version of `semver` being used has a ReDos security vulnerability detected by Snyk. A more recent version of `semver` resolved this issue (v7.5.2 and above). I bumped the `semver` version to its latest to resolve the vulnerability (v7.5.3).

For further details on this vulnerability you can view Synks details on it [here](https://security.snyk.io/vuln/SNYK-JS-SEMVER-3247795)